### PR TITLE
Add a command to only download new files

### DIFF
--- a/git-media.gemspec
+++ b/git-media.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{git-media}
-  s.version = "0.1.2"
+  s.version = "0.1.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Scott Chacon"]

--- a/lib/git-media.rb
+++ b/lib/git-media.rb
@@ -109,6 +109,9 @@ module GitMedia
         when "sync"
           require 'git-media/sync'
           GitMedia::Sync.run!
+        when "download"
+          require 'git-media/sync'
+          GitMedia::Sync.run! :download_only => true
         when 'status'
           require 'git-media/status'
           Trollop::options do
@@ -117,12 +120,12 @@ module GitMedia
           GitMedia::Status.run!
         else
 	  print <<EOF
-usage: git media sync|status|clear
+usage: git media sync|download|status|clear
 
-  sync		Sync files with remote server
-  status	Show files that are waiting to be uploaded and file size
-  clear		Upload and delete the local cache of media files
-
+  sync     Sync files with remote server
+  download Download files that are missing; don't upload any files
+  status   Show files that are waiting to be uploaded and file size
+  clear    Upload and delete the local cache of media files
 EOF
         end
       

--- a/lib/git-media/sync.rb
+++ b/lib/git-media/sync.rb
@@ -5,12 +5,15 @@ require 'git-media/status'
 module GitMedia
   module Sync
 
-    def self.run!
+    def self.run!(options={})
       @push = GitMedia.get_push_transport
       @pull = GitMedia.get_pull_transport
       
       self.expand_references
-      self.upload_local_cache
+
+      if !options.has_key?(:download_only)
+        self.upload_local_cache
+      end
     end
     
     def self.expand_references


### PR DESCRIPTION
I'm using git-media to deploy a repository that contains hundreds of binary files. Right now the sync command (over scp) tries to verify the existence of all these files on the remote directory. Since I want this repo to be pull-only, I'm only interested in downloading any new files that have been added.

This pull request adds a new command called 'download' that skips the upload step in sync.

I also bumped the version number to 0.1.5 since this is a UI change, and also because there seems to be a discrepancy between the gemspec in this repo and the version of the gem on rubygems.org (it's 0.1.4 on rubygems).
