### PR TITLE
Set UTF8 encoding to handle string split error in status.rb

### DIFF
--- a/lib/git-media/status.rb
+++ b/lib/git-media/status.rb
@@ -1,4 +1,5 @@
 require 'pp'
+Encoding.default_external = Encoding::UTF_8
 
 module GitMedia
   module Status


### PR DESCRIPTION
The issue was detected on a Japanese Windows, in which this error occurred:

"invalid byte sequence in Windows-31J"
