### PR TITLE
Media recovery binmode

### DIFF
--- a/lib/git-media/filter-clean.rb
+++ b/lib/git-media/filter-clean.rb
@@ -17,6 +17,7 @@ module GitMedia
       # read in buffered chunks of the data
       #  calculating the SHA and copying to a tempfile
       tempfile = Tempfile.new('media')
+      tempfile.binmode      
       while data = STDIN.read(4096)
         hashfunc.update(data)
         tempfile.write(data)

--- a/lib/git-media/filter-clean.rb
+++ b/lib/git-media/filter-clean.rb
@@ -12,8 +12,17 @@ module GitMedia
       hashfunc = Digest::SHA1.new
       start = Time.now
 
-      # TODO: read first 41 bytes and see if this is a stub
-      
+      #read first 41 bytes and see if this is a stub
+      possible_sha = STDIN.read(64) # read no more than 64 bytes
+      possible_sha_strip = possible_sha.strip
+      if STDIN.eof? && possible_sha_strip.length == 40 && possible_sha_strip.match(/^[0-9a-fA-F]+$/) != nil
+        # STUB
+        STDOUT.print(possible_sha)
+        STDOUT.binmode
+        STDERR.puts("Media not downloaded yet: " + possible_sha)
+        return
+      end      
+
       # read in buffered chunks of the data
       #  calculating the SHA and copying to a tempfile
       tempfile = Tempfile.new('media')

--- a/lib/git-media/filter-clean.rb
+++ b/lib/git-media/filter-clean.rb
@@ -27,6 +27,8 @@ module GitMedia
       #  calculating the SHA and copying to a tempfile
       tempfile = Tempfile.new('media')
       tempfile.binmode      
+      hashfunc.update(possible_sha)
+      tempfile.write(possible_sha)      
       while data = STDIN.read(4096)
         hashfunc.update(data)
         tempfile.write(data)

--- a/lib/git-media/filter-smudge.rb
+++ b/lib/git-media/filter-smudge.rb
@@ -27,10 +27,12 @@ module GitMedia
                 self.recover_media(media_file,sha)
               else
                 STDERR.puts('downloading media failed : ' + cache_file)
+                STDOUT.binmode 
                 puts sha
               end              
             else
               STDERR.puts('media file not found : ' + cache_file)
+              STDOUT.binmode 
               puts sha             
             end          
           end

--- a/lib/git-media/filter-smudge.rb
+++ b/lib/git-media/filter-smudge.rb
@@ -3,32 +3,53 @@ module GitMedia
 
     def self.run!
       media_buffer = GitMedia.get_media_buffer
-      can_download = false # TODO: read this from config and implement
-      
+      can_download = true # TODO: read this from config and implement
+     
       # read checksum size
       sha = STDIN.readline(64).strip # read no more than 64 bytes
       if STDIN.eof? && sha.length == 40 && sha.match(/^[0-9a-fA-F]+$/) != nil
         # this is a media file
         media_file = File.join(media_buffer, sha.chomp)
         if File.exists?(media_file)
-          STDERR.puts('recovering media : ' + sha)
-          File.open(media_file, 'r') do |f|
-            while data = f.read(4096) do
-              print data
-            end
-          end
+          self.recover_media(media_file,sha)
         else
           # TODO: download file if not in the media buffer area
           if !can_download
             STDERR.puts('media missing, saving placeholder : ' + sha)
             puts sha
+          else
+            #download file to the media buffer area
+            @pull = GitMedia.get_pull_transport
+            cache_file = GitMedia.media_path(sha)
+            if !File.exist?(cache_file)
+              @pull.pull(media_file, sha) 
+              if File.exists?(media_file)
+                self.recover_media(media_file,sha)
+              else
+                STDERR.puts('downloading media failed : ' + cache_file)
+              end              
+            else
+              STDERR.puts('media file not found : ' + cache_file)
+            end
+          
           end
         end
       else
         # if it is not a 40 character long hash, just output
         STDERR.puts('Unknown git-media file format')
+        STDOUT.binmode      
         print sha
         while data = STDIN.read(4096)
+          print data
+        end
+      end
+    end
+    
+    def self.recover_media(media_file,sha)    
+      STDERR.puts('recovering media : ' + sha)
+      STDOUT.binmode      
+      File.open(media_file, 'rb') do |f|
+        while data = f.read(4096) do
           print data
         end
       end

--- a/lib/git-media/filter-smudge.rb
+++ b/lib/git-media/filter-smudge.rb
@@ -27,11 +27,12 @@ module GitMedia
                 self.recover_media(media_file,sha)
               else
                 STDERR.puts('downloading media failed : ' + cache_file)
+                puts sha
               end              
             else
               STDERR.puts('media file not found : ' + cache_file)
-            end
-          
+              puts sha             
+            end          
           end
         end
       else


### PR DESCRIPTION
- Set the tempfile creation to binary mode
- Support automatic media recovery if the file doesn't exist in the media buffer area
- Check stub in filter-clean to avoid modifying files which haven't been synced
