### PR TITLE
Fixed bugs in find_references

### DIFF
--- a/lib/git-media/status.rb
+++ b/lib/git-media/status.rb
@@ -14,13 +14,14 @@ module GitMedia
     # find tree entries that are likely media references
     def self.find_references
       references = {:to_expand => [], :expanded => [], :deleted => []}
-      files = `git ls-tree -lz -r HEAD | tr "\\000" \\\\n`.split("\n")
+      files = `git ls-tree -l -r HEAD | tr "\\000" \\\\n`.split("\n")
       files = files.map { |f| s = f.split("\t"); [s[0].split(' ').last, s[1]] }
       files = files.select { |f| f[0] == '41' } # it's the right size
       files.each do |tree_size, fname|
         if size = File.size?(fname)
           if size == tree_size.to_i
             # TODO: read in the data and verify that it's a sha + newline
+            fname = fname.tr("\\","") #remove backslash
             sha = File.read(fname).strip
             if sha.length == 40 && sha =~ /^[0-9a-f]+$/
               references[:to_expand] << [fname, sha]


### PR DESCRIPTION
- use -l instead of -lz in ls-tree to make sure all necessary stubs are listed
- remove backslash in find_references (issues detected on Windows)
